### PR TITLE
Link para troca de senha do DC corrigido

### DIFF
--- a/index.html
+++ b/index.html
@@ -596,7 +596,7 @@
 
           Caso decida desistir de uma disciplina nos 60 primeiros dias do semestre (aproximadamente), você pode trancar a disciplina. Ao trancar a disciplina, não poderá puxar nenhuma matéria que tenha como requisito aquela que você trancou no semestre seguinte e seu IRA irá cair. Entretanto, no histórico não irá constar reprovação.<br><br>
 
-          <span class="colorir"><b>CUIDADO</b></span>, ao não ser aprovado em 8 ou mais créditos no primeiro semestre ou em não ser aprovado em pelo menos 8 créditos em dois semestres seguidos resultará em um <span class="colorir">jubliamento</span>, ou a perda do vínculo entre você e a UFSCar. Caso isso acontece você poderá tentar algum recurso, para justificar e reaver a sua vaga.<br><br>
+          <span class="colorir"><b>CUIDADO</b></span>, ao não ser aprovado em 8 ou mais créditos no primeiro semestre ou em não ser aprovado em pelo menos 8 créditos em dois semestres seguidos resultará em um <span class="colorir">jubilamento</span>, ou a perda do vínculo entre você e a UFSCar. Caso isso aconteça, você poderá tentar algum recurso para justificar e reaver a sua vaga.<br><br>
         </div>
 
         <h3>Disciplinas obrigatórias, optativas e eletivas</h3>
@@ -631,7 +631,7 @@
 
         No DC existem 6 Laboratórios de Ensino (LEs), sendo o LE1 e LE5 de Hardware e os outros de software. Além disso temos o LIG (Laboratório de Informática para a Graduação) que fica aberto 24 horas por dia e pode ser usado para estudar. Nos laboratórios <span class="colorir"><b>só consuma água</b></span>! É proibido consumir doces, salgados, café e refrigerantes lá, e não deixe embalagens espalhados. <br><br>
 
-        Nos LEs os computadores possuem Ubuntu nativo e Windows virtualizado e a autenticação é necessária para uso, se autentique usando seu RA e como senha seu CPF. Troque de senha <a href="trocasenha.dc.ufscar.br"> aqui</a>, use uma senha forte. Lembre-se de <span class="colorir">NUNCA compartilhar sua senha com outras pessoas.</span> Você será responsabilizado caso acesse algum site que não deveria acessar aqui e não baixe torrents na rede do departamento.
+        Nos LEs os computadores possuem Ubuntu nativo e Windows virtualizado e a autenticação é necessária para uso, se autentique usando seu RA e como senha seu CPF. Troque de senha <a href="https://trocasenha.dc.ufscar.br"> aqui</a>, use uma senha forte. Lembre-se de <span class="colorir">NUNCA compartilhar sua senha com outras pessoas.</span> Você será responsabilizado caso acesse algum site que não deveria acessar aqui e não baixe torrents na rede do departamento.
         
       </div>
 


### PR DESCRIPTION
Estava redirecionando para https://jonathangouvea.github.io/GuiaEnC/trocasenha.dc.ufscar.br